### PR TITLE
8316367: [Lilliput/JDK21] Provide infrastructure for Lilliput-specific ProblemList

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -829,6 +829,11 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
+  # Add more Lilliput-specific ProblemLists when UCOH is enabled
+  ifneq ($$(findstring -XX:+UseCompactObjectHeaders, $$(TEST_OPTS)), )
+    JTREG_EXTRA_PROBLEM_LISTS += $(TOPDIR)/test/hotspot/jtreg/ProblemList-lilliput.txt
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \

--- a/test/hotspot/jtreg/ProblemList-lilliput.txt
+++ b/test/hotspot/jtreg/ProblemList-lilliput.txt
@@ -1,0 +1,28 @@
+#
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#
+# These tests are problematic when +UseCompactObjectHeaders is enabled.
+# The test exclusions are for the cases when we are sure the tests would fail
+# for the known and innocuous implementation reasons.
+#


### PR DESCRIPTION
We should add the infrastructure for excluding the tests which are known to fail with Lilliput, to get clean test runs.
Same as https://github.com/openjdk/lilliput/pull/100 but for Lilliput/21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316367](https://bugs.openjdk.org/browse/JDK-8316367): [Lilliput/JDK21] Provide infrastructure for Lilliput-specific ProblemList (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/6.diff">https://git.openjdk.org/lilliput-jdk21u/pull/6.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/6#issuecomment-1721383626)