### PR TITLE
8316424: [Lilliput/JDK21] ZGC/CDS-related test fixes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java
@@ -56,6 +56,7 @@ public class TestZGCWithCDS {
     public final static String ERR_MSG = "The saved state of UseCompressedOops and UseCompressedClassPointers is different from runtime, CDS will be disabled.";
     public static void main(String... args) throws Exception {
          String zGenerational = args[0];
+         String compactHeaders = "-XX:" + (zGenerational.equals("-XX:+ZGenerational") ? "+" : "-") + "UseCompactObjectHeaders";
          String helloJar = JarBuilder.build("hello", "Hello");
          System.out.println("0. Dump with ZGC");
          OutputAnalyzer out = TestCommon
@@ -63,6 +64,8 @@ public class TestZGCWithCDS {
                                         new String[] {"Hello"},
                                         "-XX:+UseZGC",
                                         zGenerational,
+                                        "-XX:+UnlockExperimentalVMOptions",
+                                        compactHeaders,
                                         "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
          out.shouldHaveExitValue(0);
@@ -72,6 +75,8 @@ public class TestZGCWithCDS {
                    .exec(helloJar,
                          "-XX:+UseZGC",
                          zGenerational,
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);
@@ -83,6 +88,8 @@ public class TestZGCWithCDS {
                          "-XX:-UseZGC",
                          "-XX:+UseCompressedOops",           // in case turned off by vmoptions
                          "-XX:+UseCompressedClassPointers",  // by jtreg
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -107,6 +114,8 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);
@@ -130,6 +139,8 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:+UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(UNABLE_TO_USE_ARCHIVE);
@@ -143,6 +154,8 @@ public class TestZGCWithCDS {
                          "-XX:+UseSerialGC",
                          "-XX:-UseCompressedOops",
                          "-XX:+UseCompressedClassPointers",
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds");
          out.shouldContain("Dumping shared data to file:");
          out.shouldHaveExitValue(0);
@@ -152,6 +165,8 @@ public class TestZGCWithCDS {
                    .exec(helloJar,
                          "-XX:+UseZGC",
                          zGenerational,
+                         "-XX:+UnlockExperimentalVMOptions",
+                         compactHeaders,
                          "-Xlog:cds",
                          "Hello");
          out.shouldContain(HELLO);

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -167,7 +167,7 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
                     String zGenerational = "-XX:" + (useZGenerational ? "+" : "-") + "ZGenerational";
                     // Add options to force eager class unloading.
                     cmdLine = TestCommon.concat(cmdLine, "-cp", loaderJar,
-                                                "-XX:+UseZGC", zGenerational, "-XX:ZCollectionInterval=0.01",
+                                                "-XX:+UseZGC", zGenerational, "-XX:ZCollectionInterval=0.01", "-XX:+UnlockExperimentalVMOptions", "-XX:-UseCompactObjectHeaders",
                                                 loaderMainClass, appJar);
                     setBaseArchiveOptions("-XX:+UseZGC", "-Xlog:cds");
                 } else {


### PR DESCRIPTION
A few tests with ZGC and CDS are failing. Reason is that we disable COH with single-gen-ZGC but not with gen-ZGC, and some tests dump with one and run with the other. This causes unexpected mismatches.

Testing:
 - [x] runtime/cds/appcds/TestZGCWithCDS.java (default)
 - [x] runtime/cds/appcds/TestZGCWithCDS.java (+UCOH)
 - [x] runtime/cds/appcds/TestZGCWithCDS.java (-UCOH)
 - [x] runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java (default)
 - [x] runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java (+UCOH)
 - [x] runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java (-UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316424](https://bugs.openjdk.org/browse/JDK-8316424): [Lilliput/JDK21] ZGC/CDS-related test fixes (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/7.diff">https://git.openjdk.org/lilliput-jdk21u/pull/7.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/7#issuecomment-1723357626)