### PR TITLE
8316442: [Lilliput/JDK21] Problem-list compiler/ciReplay tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList-lilliput.txt
+++ b/test/hotspot/jtreg/ProblemList-lilliput.txt
@@ -26,3 +26,15 @@
 # The test exclusions are for the cases when we are sure the tests would fail
 # for the known and innocuous implementation reasons.
 #
+
+
+compiler/ciReplay/TestInlining.java 8316441 generic-all
+compiler/ciReplay/TestInliningProtectionDomain.java 8316441 generic-all
+compiler/ciReplay/TestServerVM.java 8316441 generic-all
+compiler/ciReplay/TestUnresolvedClasses.java 8316441 generic-all
+compiler/ciReplay/TestLambdas.java 8316441 generic-all
+compiler/ciReplay/TestDumpReplay.java 8316441 generic-all
+compiler/ciReplay/TestDumpReplayCommandLine.java 8316441 generic-all
+compiler/ciReplay/TestIncrementalInlining.java 8316441 generic-all
+compiler/ciReplay/TestInvalidReplayFile.java 8316441 generic-all
+compiler/ciReplay/TestNoClassFile.java 8316441 generic-all


### PR DESCRIPTION
Some tests in compiler/ciReplay seem to be sensitivs to setting of +/-UCOH when generating vs loading compiler replays. This only affects JIT diagnosis and can in practice likely be worked-around by using the correct combination of flags. Let's problem-list the tests for now.

Tests:
 - [x] compiler/ciReplay +UCOH
 - [x] compiler/ciReplay -UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316442](https://bugs.openjdk.org/browse/JDK-8316442): [Lilliput/JDK21] Problem-list compiler/ciReplay tests (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/8.diff">https://git.openjdk.org/lilliput-jdk21u/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/8#issuecomment-1724173469)