### PR TITLE
8316687: [Lilliput/JDK21] Various cleanups

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -198,11 +198,6 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
 
   if (len->is_valid()) {
     strw(len, Address(obj, arrayOopDesc::length_offset_in_bytes()));
-    if (UseCompactObjectHeaders) {
-      // With compact headers, arrays have a 32bit alignment gap after the length.
-      assert(arrayOopDesc::length_offset_in_bytes() == 8, "check length offset");
-      strw(zr, Address(obj, arrayOopDesc::length_offset_in_bytes() + sizeof(jint)));
-    }
   } else if (UseCompressedClassPointers && !UseCompactObjectHeaders) {
     store_klass_gap(obj, zr);
   }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4327,7 +4327,7 @@ void MacroAssembler::load_nklass_compact(Register dst, Register src) {
   // Fetch displaced header
   ldr(dst, Address(dst, OM_OFFSET_NO_MONITOR_VALUE_TAG(header)));
 
-  // Fast-path: shift and decode Klass*.
+  // Fast-path: shift to get narrowKlass.
   bind(fast);
   lsr(dst, dst, markWord::klass_shift);
 }

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3569,6 +3569,7 @@ void TemplateTable::_new() {
     // The object is initialized before the header.  If the object size is
     // zero, go directly to the header initialization.
     if (UseCompactObjectHeaders) {
+      assert(is_aligned(oopDesc::base_offset_in_bytes(), BytesPerLong), "oop base offset must be 8-byte-aligned");
       __ sub(r3, r3, oopDesc::base_offset_in_bytes());
     } else {
       __ sub(r3, r3, sizeof(oopDesc));
@@ -3578,12 +3579,8 @@ void TemplateTable::_new() {
     // Initialize object fields
     {
       if (UseCompactObjectHeaders) {
+        assert(is_aligned(oopDesc::base_offset_in_bytes(), BytesPerLong), "oop base offset must be 8-byte-aligned");
         __ add(r2, r0, oopDesc::base_offset_in_bytes());
-        if (!is_aligned(oopDesc::base_offset_in_bytes(), BytesPerLong)) {
-          __ strw(zr, Address(__ post(r2, BytesPerInt)));
-          __ sub(r3, r3, BytesPerInt);
-          __ cbz(r3, initialize_header);
-        }
       } else {
         __ add(r2, r0, sizeof(oopDesc));
       }

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -971,7 +971,7 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
                       op->tmp1()->as_register(),
                       op->tmp2()->as_register(),
                       op->tmp3()->as_register(),
-                      align_up(arrayOopDesc::header_size_in_bytes(), HeapWordSize) / HeapWordSize,
+                      arrayOopDesc::base_offset_in_bytes(op->type()),
                       type2aelembytes(op->type()),
                       op->klass()->as_register(),
                       *op->stub()->entry());

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -218,9 +218,8 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
   assert((con_size_in_bytes & MinObjAlignmentInBytesMask) == 0,
          "con_size_in_bytes is not multiple of alignment");
   const int hdr_size_in_bytes = instanceOopDesc::header_size() * HeapWordSize;
-  if (UseCompactObjectHeaders) {
-    assert(hdr_size_in_bytes == 8, "check object headers size");
-  }
+  assert(!UseCompactObjectHeaders || hdr_size_in_bytes == 8, "check object headers size");
+
   initialize_header(obj, klass, noreg, t1, t2);
 
   if (!(UseTLAB && ZeroTLAB && is_tlab_allocated)) {

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -182,14 +182,6 @@ void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register
 
   if (len->is_valid()) {
     movl(Address(obj, arrayOopDesc::length_offset_in_bytes()), len);
-#ifdef _LP64
-    if (!is_aligned(arrayOopDesc::header_size_in_bytes(), BytesPerWord)) {
-      assert(is_aligned(arrayOopDesc::header_size_in_bytes(), BytesPerInt), "must be 4-byte aligned");
-      movl(Address(obj, arrayOopDesc::header_size_in_bytes()), 0);
-    }
-#else
-    assert(is_aligned(arrayOopDesc::header_size_in_bytes(), BytesPerInt), "must be 4-byte aligned");
-#endif
   }
 #ifdef _LP64
   else if (UseCompressedClassPointers && !UseCompactObjectHeaders) {
@@ -296,12 +288,22 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
 
   initialize_header(obj, klass, len, t1, t2);
 
+  // Clear leading 4 bytes, if necessary.
+  // TODO: This could perhaps go into initialize_body() and also clear the leading 4 bytes
+  // for non-array objects, thereby replacing the klass-gap clearing code in initialize_header().
+  int base_offset = base_offset_in_bytes;
+#ifdef _LP64
+  if (!is_aligned(base_offset, BytesPerWord)) {
+    assert(is_aligned(base_offset, BytesPerInt), "must be 4-byte aligned");
+    movl(Address(obj, base_offset), 0);
+    base_offset += BytesPerInt;
+  }
+#endif
+  assert(is_aligned(base_offset, BytesPerWord), "must be word aligned");
+
   // clear rest of allocated space
   const Register len_zero = len;
-  // We align-up the header size to word-size, because we clear the
-  // possible alignment gap in initialize_header().
-  int hdr_size = align_up(base_offset_in_bytes, BytesPerWord);
-  initialize_body(obj, arr_size, hdr_size, len_zero);
+  initialize_body(obj, arr_size, base_offset, len_zero);
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == rax, "must be");

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4033,7 +4033,8 @@ void TemplateTable::_new() {
     // The object is initialized before the header.  If the object size is
     // zero, go directly to the header initialization.
     if (UseCompactObjectHeaders) {
-      __ decrement(rdx, align_up(oopDesc::base_offset_in_bytes(), BytesPerLong));
+      assert(is_aligned(oopDesc::base_offset_in_bytes(), BytesPerLong), "oop base offset must be 8-byte-aligned");
+      __ decrement(rdx, oopDesc::base_offset_in_bytes());
     } else {
       __ decrement(rdx, sizeof(oopDesc));
     }
@@ -4059,7 +4060,8 @@ void TemplateTable::_new() {
     { Label loop;
     __ bind(loop);
     if (UseCompactObjectHeaders) {
-      int header_size = align_up(oopDesc::base_offset_in_bytes(), BytesPerLong);
+      assert(is_aligned(oopDesc::base_offset_in_bytes(), BytesPerLong), "oop base offset must be 8-byte-aligned");
+      int header_size = oopDesc::base_offset_in_bytes();
       __ movptr(Address(rax, rdx, Address::times_8, header_size - 1*oopSize), rcx);
       NOT_LP64(__ movptr(Address(rax, rdx, Address::times_8, header_size - 2*oopSize), rcx));
     } else {

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -254,6 +254,8 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
   // Copy obj
   Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
 
+  // Parallel GC claims with a release - so other threads might access this object
+  // after claiming and they should see the "completed" object.
   if (UseCompactObjectHeaders) {
     // The copy above is not atomic. Make sure we have seen the proper mark
     // and re-install it into the copy, so that Klass* is guaranteed to be correct.

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -402,8 +402,6 @@ void CollectedHeap::set_gc_cause(GCCause::Cause v) {
   _gc_cause = v;
 }
 
-// Should only be called with constants as argument
-// (will not constant fold otherwise)
 // Returns the header size in words aligned to the requirements of the
 // array object type.
 static int int_array_header_size() {

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -183,4 +183,5 @@ void ContiguousSpace::oop_since_save_marks_iterate(OopClosureType* blk) {
 
   set_saved_mark_word(p);
 }
+
 #endif // SHARE_GC_SHARED_SPACE_INLINE_HPP

--- a/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
@@ -77,7 +77,7 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
   // Signal to the ZIterator that this is an invisible root, by setting
   // the mark word to "marked". Reset to prototype() after the clearing.
   if (UseCompactObjectHeaders) {
-    oopDesc::release_set_mark(mem, _klass->prototype_header().set_marked());
+    arrayOopDesc::release_set_mark(mem, _klass->prototype_header().set_marked());
   } else {
     arrayOopDesc::set_mark(mem, markWord::prototype().set_marked());
     arrayOopDesc::release_set_klass(mem, _klass);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -439,12 +439,7 @@ C2V_VMENTRY_NULL(jobject, getResolvedJavaType0, (JNIEnv* env, jobject, jobject b
 
   const char* base_desc = nullptr;
   JVMCIKlassHandle klass(THREAD);
-
-  // With compact object headers, we can test for the explicit offset within
-  // the header to figure out if compiler code is accessing the class. See
-  // more discussion in C2, TypeOopPtr::klass_offset_in_bytes().
-  int klass_offset = UseCompactObjectHeaders ? 4 : oopDesc::klass_offset_in_bytes();
-  if (offset == klass_offset) {
+  if (offset == oopDesc::klass_offset_in_bytes()) {
     if (JVMCIENV->isa_HotSpotObjectConstantImpl(base_object)) {
       Handle base_oop = JVMCIENV->asConstant(base_object, JVMCI_CHECK_NULL);
       klass = base_oop->klass();

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -345,7 +345,9 @@ public:
       return mark_offset_in_bytes() + markWord::klass_shift / 8;
     } else
 #endif
-    return (int)offset_of(oopDesc, _metadata._klass);
+    {
+      return (int)offset_of(oopDesc, _metadata._klass);
+    }
   }
   static int klass_gap_offset_in_bytes() {
     assert(has_klass_gap(), "only applicable to compressed klass pointers");

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -102,7 +102,7 @@ markWord oopDesc::prototype_mark() const {
 
 void oopDesc::init_mark() {
   if (UseCompactObjectHeaders) {
-    set_mark(prototype_mark());
+    set_mark(klass()->prototype_header());
   } else {
     set_mark(markWord::prototype());
   }

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1399,7 +1399,7 @@ class TypeAryPtr : public TypeOopPtr {
 
     if (UseCompressedOops && (elem()->make_oopptr() != nullptr && !top_or_bottom) &&
         _offset != 0 && _offset != arrayOopDesc::length_offset_in_bytes() &&
-        _offset != oopDesc::klass_offset_in_bytes()) {
+        _offset != arrayOopDesc::klass_offset_in_bytes()) {
       _is_ptr_to_narrowoop = true;
     }
 


### PR DESCRIPTION
Review of upstream diff has revealed various minor issues. Let's fix them collectively.

Testing:
 - [x] hotspot:tier1 +UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316687](https://bugs.openjdk.org/browse/JDK-8316687): [Lilliput/JDK21] Various cleanups (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/9.diff">https://git.openjdk.org/lilliput-jdk21u/pull/9.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/9#issuecomment-1730043746)