### PR TITLE
8317954: [Lilliput/JDK21] Make C2 LoadNKlassCompactHeader more robust

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7339,9 +7339,7 @@ instruct loadNKlassCompactHeaders(iRegNNoSp dst, memory4 mem, rFlagsReg cr)
   ins_cost(4 * INSN_COST);
   format %{ "ldrw  $dst, $mem\t# compressed class ptr" %}
   ins_encode %{
-    assert($mem$$disp == oopDesc::klass_offset_in_bytes(), "expect correct offset");
-    assert($mem$$index$$Register == noreg, "expect no index");
-    __ load_nklass_compact($dst$$Register, $mem$$base$$Register);
+    __ load_nklass_compact($dst$$Register, $mem$$base$$Register, $mem$$index$$Register, $mem$$scale, $mem$$disp);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -2059,10 +2059,25 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
   return MacroAssembler::in_scratch_emit_size();
 }
 
-void C2_MacroAssembler::load_nklass_compact(Register dst, Register obj) {
+void C2_MacroAssembler::load_nklass_compact(Register dst, Register obj, Register index, int scale, int disp) {
   C2LoadNKlassStub* stub = new (Compile::current()->comp_arena()) C2LoadNKlassStub(dst);
   Compile::current()->output()->add_stub(stub);
-  ldr(dst, Address(obj, oopDesc::mark_offset_in_bytes()));
+
+  // Note: Don't clobber obj anywhere in that method!
+
+  // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
+  // obj-start, so that we can load from the object's mark-word instead. Usually the address
+  // comes as obj-start in obj and klass_offset_in_bytes in disp. However, sometimes C2
+  // emits code that pre-computes obj-start + klass_offset_in_bytes into a register, and
+  // then passes that register as obj and 0 in disp. The following code extracts the base
+  // and offset to load the mark-word.
+  int offset = oopDesc::mark_offset_in_bytes() + disp - oopDesc::klass_offset_in_bytes();
+  if (index == noreg) {
+    ldr(dst, Address(obj, offset));
+  } else {
+    lea(dst, Address(obj, index, Address::lsl(scale)));
+    ldr(dst, Address(dst, offset));
+  }
   // NOTE: We can't use tbnz here, because the target is sometimes too far away
   // and cannot be encoded.
   tst(dst, markWord::monitor_value);

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -172,6 +172,6 @@
   void vector_signum_sve(FloatRegister dst, FloatRegister src, FloatRegister zero,
                          FloatRegister one, FloatRegister vtmp, PRegister pgtmp, SIMD_RegVariant T);
 
-  void load_nklass_compact(Register dst, Register obj);
+  void load_nklass_compact(Register dst, Register obj, Register index, int scale, int disp);
 
 #endif // CPU_AARCH64_C2_MACROASSEMBLER_AARCH64_HPP

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -6181,10 +6181,20 @@ void C2_MacroAssembler::vector_rearrange_int_float(BasicType bt, XMMRegister dst
 }
 
 #ifdef _LP64
-void C2_MacroAssembler::load_nklass_compact_c2(Register dst, Register obj) {
+void C2_MacroAssembler::load_nklass_compact_c2(Register dst, Register obj, Register index, Address::ScaleFactor scale, int disp) {
   C2LoadNKlassStub* stub = new (Compile::current()->comp_arena()) C2LoadNKlassStub(dst);
   Compile::current()->output()->add_stub(stub);
-  movq(dst, Address(obj, oopDesc::mark_offset_in_bytes()));
+
+  // Note: Don't clobber obj anywhere in that method!
+
+  // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
+  // obj-start, so that we can load from the object's mark-word instead. Usually the address
+  // comes as obj-start in obj and klass_offset_in_bytes in disp. However, sometimes C2
+  // emits code that pre-computes obj-start + klass_offset_in_bytes into a register, and
+  // then passes that register as obj and 0 in disp. The following code extracts the base
+  // and offset to load the mark-word.
+  int offset = oopDesc::mark_offset_in_bytes() + disp - oopDesc::klass_offset_in_bytes();
+  movq(dst, Address(obj, index, scale, offset));
   testb(dst, markWord::monitor_value);
   jcc(Assembler::notZero, stub->entry());
   bind(stub->continuation());

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -492,6 +492,6 @@ public:
   void vector_rearrange_int_float(BasicType bt, XMMRegister dst, XMMRegister shuffle,
                                   XMMRegister src, int vlen_enc);
 
-  void load_nklass_compact_c2(Register dst, Register obj);
+  void load_nklass_compact_c2(Register dst, Register obj, Register index, Address::ScaleFactor scale, int disp);
 
 #endif // CPU_X86_C2_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5334,7 +5334,7 @@ instruct loadNKlassCompactHeaders(rRegN dst, indOffset8 mem, rFlagsReg cr)
   format %{ "movl    $dst, $mem\t# compressed klass ptr" %}
   ins_encode %{
     Register index = $mem$$index != 4 ? $mem$$index$$Register : noreg;
-    Address::ScaleFactor sf = $mem$$scale != 0 ? Address::times($mem$$scale) : Address::no_scale;
+    Address::ScaleFactor sf = $mem$$index != 4 ? static_cast<Address::ScaleFactor>($mem$$scale) : Address::no_scale;
     __ load_nklass_compact_c2($dst$$Register, $mem$$base$$Register, index, sf, $mem$$disp);
   %}
   ins_pipe(pipe_slow); // XXX

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5325,7 +5325,7 @@ instruct loadNKlass(rRegN dst, memory mem)
   ins_pipe(ialu_reg_mem); // XXX
 %}
 
-instruct loadNKlassCompactHeaders(rRegN dst, indOffset8 mem, rFlagsReg cr)
+instruct loadNKlassCompactHeaders(rRegN dst, memory mem, rFlagsReg cr)
 %{
   predicate(UseCompactObjectHeaders);
   match(Set dst (LoadNKlass mem));
@@ -5334,7 +5334,7 @@ instruct loadNKlassCompactHeaders(rRegN dst, indOffset8 mem, rFlagsReg cr)
   format %{ "movl    $dst, $mem\t# compressed klass ptr" %}
   ins_encode %{
     Register index = $mem$$index != 4 ? $mem$$index$$Register : noreg;
-    Address::ScaleFactor sf = $mem$$index != 4 ? static_cast<Address::ScaleFactor>($mem$$scale) : Address::no_scale;
+    Address::ScaleFactor sf = (index != noreg) ? static_cast<Address::ScaleFactor>($mem$$scale) : Address::no_scale;
     __ load_nklass_compact_c2($dst$$Register, $mem$$base$$Register, index, sf, $mem$$disp);
   %}
   ins_pipe(pipe_slow); // XXX

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5333,9 +5333,9 @@ instruct loadNKlassCompactHeaders(rRegN dst, indOffset8 mem, rFlagsReg cr)
   ins_cost(125); // XXX
   format %{ "movl    $dst, $mem\t# compressed klass ptr" %}
   ins_encode %{
-    assert($mem$$disp == oopDesc::klass_offset_in_bytes(), "expect correct offset 4, but got: %d", $mem$$disp);
-    assert($mem$$index == 4, "expect no index register: %d", $mem$$index);
-    __ load_nklass_compact_c2($dst$$Register, $mem$$base$$Register);
+    Register index = $mem$$index != 4 ? $mem$$index$$Register : noreg;
+    Address::ScaleFactor sf = $mem$$scale != 0 ? Address::times($mem$$scale) : Address::no_scale;
+    __ load_nklass_compact_c2($dst$$Register, $mem$$base$$Register, index, sf, $mem$$disp);
   %}
   ins_pipe(pipe_slow); // XXX
 %}


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/lilliput/pull/111.
Lilliput's C2 code for generating LoadNKlass currently assumes that the disp of the incoming address is klass_offset_in_bytes. It then extracts the base register and loads from the mark_offset_in_bytes instead.
Sometimes (apparently very rarely) it happens that C2 emits code that pre-adds obj+klass_offset into a register, and uses that as base, but with offset 0. In this case we would trip the assert or crash in release builds.

- [x] specjvm derby (which triggered the bug)
- [x] tier1 x86_64 +UCOH
- [x] tier1 aarch64 +UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317954](https://bugs.openjdk.org/browse/JDK-8317954): [Lilliput/JDK21] Make C2 LoadNKlassCompactHeader more robust (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/10.diff">https://git.openjdk.org/lilliput-jdk21u/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/10#issuecomment-1757694383)