### PR TITLE
8319135: [Lilliput] Fix objArrayOop gtest

### DIFF
--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -28,29 +28,41 @@
 
 TEST_VM(objArrayOop, osize) {
   static const struct {
-    int objal; bool ccp; bool coops; int result;
+    int objal; bool ccp; bool coops; bool coh; int result;
   } x[] = {
-//    ObjAligInB, UseCCP, UseCoops, object size in heap words
+//    ObjAligInB, UseCCP, UseCoops, UseCOH, object size in heap words
 #ifdef _LP64
-    { 8,          false,  false,    4 },  // 20 byte header, 8 byte oops
-    { 8,          false,  true,     3 },  // 20 byte header, 4 byte oops
-    { 8,          true,   false,    3 },  // 16 byte header, 8 byte oops
-    { 8,          true,   true,     3 },  // 16 byte header, 4 byte oops
-    { 16,         false,  false,    4 },  // 20 byte header, 8 byte oops, 16-byte align
-    { 16,         false,  true,     4 },  // 20 byte header, 4 byte oops, 16-byte align
-    { 16,         true,   false,    4 },  // 16 byte header, 8 byte oops, 16-byte align
-    { 16,         true,   true,     4 },  // 16 byte header, 4 byte oops, 16-byte align
-    { 256,        false,  false,    32 }, // 20 byte header, 8 byte oops, 256-byte align
-    { 256,        false,  true,     32 }, // 20 byte header, 4 byte oops, 256-byte align
-    { 256,        true,   false,    32 }, // 16 byte header, 8 byte oops, 256-byte align
-    { 256,        true,   true,     32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    false,  4 },  // 20 byte header, 8 byte oops
+    { 8,          false,  true,     false,  3 },  // 20 byte header, 4 byte oops
+    { 8,          true,   false,    false,  3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     false,  3 },  // 16 byte header, 4 byte oops
+    { 16,         false,  false,    false,  4 },  // 20 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     false,  4 },  // 20 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    false,  4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     false,  4 },  // 16 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    false,  32 }, // 20 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     false,  32 }, // 20 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    false,  32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     false,  32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          false,  true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 8,          true,   false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 16,         false,  false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
 #else
-    { 8,          false,  false,    4 }, // 12 byte header, 4 byte oops, wordsize 4
+    { 8,          false,  false,    false,  4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif
-    { -1,         false,  false,   -1 }
+    { -1,         false,  false,    false, -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
-    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops) {
+    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops && x[i].coh == UseCompactObjectHeaders) {
       EXPECT_EQ(objArrayOopDesc::object_size(1), (size_t)x[i].result);
     }
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fc9020fb](https://github.com/openjdk/lilliput/commit/fc9020fbf193b1c6d2b2fb5d80192c3082dbcf2e) from the [openjdk/lilliput](https://git.openjdk.org/lilliput) repository.

The commit being backported was authored by Roman Kennke on 1 Nov 2023 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319135](https://bugs.openjdk.org/browse/JDK-8319135): [Lilliput] Fix objArrayOop gtest (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/12.diff">https://git.openjdk.org/lilliput-jdk21u/pull/12.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/12#issuecomment-1794602398)