### PR TITLE
8319524: [Lilliput] Only warn when compact headers are explicitly enabled

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3097,7 +3097,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #ifdef _LP64
   if (UseCompactObjectHeaders && UseZGC && !ZGenerational) {
-    warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    if (FLAG_IS_CMDLINE(UseCompactObjectHeaders)) {
+      warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    }
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3f73f014](https://github.com/openjdk/lilliput/commit/3f73f014097262455cc42a71c32af374b77b6efd) from the [openjdk/lilliput](https://git.openjdk.org/lilliput) repository.

The commit being backported was authored by Roman Kennke on 6 Nov 2023 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319524](https://bugs.openjdk.org/browse/JDK-8319524): [Lilliput] Only warn when compact headers are explicitly enabled (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/13.diff">https://git.openjdk.org/lilliput-jdk21u/pull/13.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/13#issuecomment-1795354889)