### PR TITLE
8329091: [Lilliput/JDK21] Fix tests after LM_LIGHTWEIGHT backports

### DIFF
--- a/test/hotspot/jtreg/gtest/LockStackGtests.java
+++ b/test/hotspot/jtreg/gtest/LockStackGtests.java
@@ -28,5 +28,5 @@
  * @modules java.base/jdk.internal.misc
  *          java.xml
  * @requires vm.flagless
- * @run main/native GTestWrapper --gtest_filter=LockStackTest* -XX:LockingMode=2
+ * @run main/native GTestWrapper --gtest_filter=LockStackTest* -XX:+UnlockExperimentalVMOptions -XX:LockingMode=2
  */

--- a/test/hotspot/jtreg/runtime/lockStack/TestLockStackCapacity.java
+++ b/test/hotspot/jtreg/runtime/lockStack/TestLockStackCapacity.java
@@ -30,7 +30,7 @@
  * @library /testlibrary /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xint -XX:LockingMode=2 TestLockStackCapacity
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xint -XX:LockingMode=2 TestLockStackCapacity
  */
 
 import jdk.test.lib.Asserts;

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -132,7 +132,7 @@
  *                 -XX:+WhiteBoxAPI
  *                 -Xbatch
  *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks
- *                 -XX:LockingMode=1
+ *                 -XX:+UnlockExperimentalVMOptions -XX:LockingMode=1
  *                 -XX:DiagnoseSyncOnValueBasedClasses=2
  *
  * @comment Re-lock may inflate monitors when re-locking, which cause monitorinflation trace logging.
@@ -144,7 +144,7 @@
  *                 -XX:+WhiteBoxAPI
  *                 -Xbatch
  *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks
- *                 -XX:LockingMode=2
+ *                 -XX:+UnlockExperimentalVMOptions -XX:LockingMode=2
  *                 -Xlog:monitorinflation=trace:file=monitorinflation.log
  *
  * @comment Re-lock may race with deflation.
@@ -156,7 +156,7 @@
  *                 -XX:+WhiteBoxAPI
  *                 -Xbatch
  *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks
- *                 -XX:LockingMode=0
+ *                 -XX:+UnlockExperimentalVMOptions -XX:LockingMode=0
  *                 -XX:GuaranteedAsyncDeflationInterval=1000
  */
 
@@ -1999,7 +1999,7 @@ class EARelockingNestedInflated_03Target extends EATestCaseBaseTarget {
         // Use new lock. lockInflatedByContention might have been inflated because of recursion.
         lockInflatedByContention = new XYVal(1, 1);
         // Start thread that tries to enter lockInflatedByContention while the main thread owns it -> inflation
-        DebuggeeWrapper.newThread(() -> {
+        TestScaffold.newThread(() -> {
             while (true) {
                 synchronized (testCase) {
                     try {


### PR DESCRIPTION
A few tests explicitely test LM_LIGHTWEIGHT locking-mode. In JDK22, LM_LIGHTWEIGHT became a non-experimental product option. Some tests that have been backported from JDK>=22 requires -XX:+UnlockExperimentalVMOptions in JDK21.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8329091](https://bugs.openjdk.org/browse/JDK-8329091): [Lilliput/JDK21] Fix tests after LM_LIGHTWEIGHT backports (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput-jdk21u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/lilliput-jdk21u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput-jdk21u/pull/29.diff">https://git.openjdk.org/lilliput-jdk21u/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput-jdk21u/pull/29#issuecomment-2020431426)